### PR TITLE
feat: use fbsim-core v1.0.0-alpha.6, correct table logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "fbsim-cli"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "clap",
  "fbsim-core",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75ecac989d1fc64c89817c03430e6241be29dc17f8b6ecc06c81614c65c63f4"
+checksum = "4cea2f0874bcd04c5a2a02f61b28232af35bd34eb178a6f391c49ba71806bec8"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-cli"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
-fbsim-core = "1.0.0-alpha.5"
+fbsim-core = "1.0.0-alpha.6"
 indicatif = "0.17.11"
 rand = "0.8.5"
 serde_json = "1.0.134"

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
     let mut tie_props = [[0.0_f64; 11]; 11];
 
     // Instantiate a progress bar for benchmark progress
-    let progress_bar = ProgressBar::new(11 * 11 * 500);
+    let progress_bar = ProgressBar::new(11 * 11 * 10000);
 
     // Run many game simulations and track the observed
     // win and tie proportions by skill differential
@@ -87,19 +87,19 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
             // Set the away offense and home defense
             let away_off = ((10 - j) * 10) as i32;
             let home_def = (j * 10) as i32;
-            for k in 1..501 {
-                // Create the home and away teams from their files
-                let home_team = FootballTeam::from_properties(
-                    "Home Team",
-                    home_off,
-                    home_def
-                ).unwrap();
-                let away_team = FootballTeam::from_properties(
-                    "Away Team",
-                    away_off,
-                    away_def
-                ).unwrap();
 
+            // Create the home and away teams
+            let home_team = FootballTeam::from_properties(
+                "Home Team",
+                home_off,
+                home_def
+            ).unwrap();
+            let away_team = FootballTeam::from_properties(
+                "Away Team",
+                away_off,
+                away_def
+            ).unwrap();
+            for k in 1..10001 {
                 // Simulate the game
                 let box_score = box_score_sim.sim(
                     &home_team,
@@ -110,7 +110,6 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
                 // Decide whether this was a tie, or home win / away win
                 let was_tie = box_score.home_score() == box_score.away_score();
                 let home_win = box_score.home_score() > box_score.away_score();
-                let away_win = box_score.home_score() < box_score.away_score();
 
                 // Increment the tie proportions
                 tie_props[i][j] = if was_tie {
@@ -118,18 +117,12 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
                 } else {
                     ((tie_props[i][j] * ((k as f64) - 1_f64)) + 0_f64) / (k as f64)
                 };
-                tie_props[j][i] = tie_props[i][j];
 
                 // Increment the win proportions
                 win_props[i][j] = if home_win {
                     ((win_props[i][j] * ((k as f64) - 1_f64) + 1_f64)) / (k as f64)
                 } else {
                     ((win_props[i][j] * ((k as f64) - 1_f64) + 0_f64)) / (k as f64)
-                };
-                win_props[j][i] = if away_win {
-                    ((win_props[j][i] * ((k as f64) - 1_f64) + 1_f64)) / (k as f64)
-                } else {
-                    ((win_props[j][i] * ((k as f64) - 1_f64) + 0_f64)) / (k as f64)
                 };
 
                 // Increment the progress bar
@@ -145,7 +138,7 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
         "\t0\t\t\t\t\t\t\t\t\t\t100"
     );
     for i in 0..11 {
-        let table_line = win_props[i].iter().map(|x| format!("{:.2}", x)).collect::<Vec<_>>().join("\t");
+        let table_line = win_props[i].iter().map(|x| format!("{:.4}", x)).collect::<Vec<_>>().join("\t");
         let table_line_pfx = if i == 0 || i == 10 {
             format!("{}", i * 10)
         } else {
@@ -164,7 +157,7 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
         "\t0\t\t\t\t\t\t\t\t\t\t100"
     );
     for i in 0..11 {
-        let table_line = tie_props[i].iter().map(|x| format!("{:.2}", x)).collect::<Vec<_>>().join("\t");
+        let table_line = tie_props[i].iter().map(|x| format!("{:.4}", x)).collect::<Vec<_>>().join("\t");
         let table_line_pfx = if i == 0 || i == 10 {
             format!("{}", i * 10)
         } else {


### PR DESCRIPTION
In this PR, I upgrade to fbsim-core v1.0.0-alpha.6 to test its re-simulation logic via the `fbsim game benchmark` command.  I found that v1.0.0-alpha.6 (where we averaged the skill diffs for the home and away teams) produced slightly more desirable results than v1.0.0-alpha.7 (where we just arbitrarily used the home-away skill diff).

I will retroactively fix this in fbsim-core by releasing v1.0.0-alpha.8 which will revert the fix and thus be exactly the same as v1.0.0-alpha.6.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/15