### PR TITLE
chore: move up to fbsim-core v1.0.0-alpha.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "fbsim-cli"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "clap",
  "fbsim-core",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cea2f0874bcd04c5a2a02f61b28232af35bd34eb178a6f391c49ba71806bec8"
+checksum = "2d0f8bb728ddb821141b908f689c7b3a2fb8b7805f407de2f4a96a1274ccbffe"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-cli"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
-fbsim-core = "1.0.0-alpha.6"
+fbsim-core = "1.0.0-alpha.8"
 indicatif = "0.17.11"
 rand = "0.8.5"
 serde_json = "1.0.134"


### PR DESCRIPTION
A small housekeeping change to make sure I'm on the latest `fbsim-core`, even though it's exactly the same in terms of its source code as the one I'm upgrading to here
- https://github.com/whatsacomputertho/fbsim-core/pull/19

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/15