### PR TITLE
feat: include score mean, std, and freq in benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,21 +157,22 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "fbsim-cli"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "clap",
  "fbsim-core",
  "indicatif",
  "rand",
  "serde_json",
+ "statrs",
  "tabwriter",
 ]
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0f8bb728ddb821141b908f689c7b3a2fb8b7805f407de2f4a96a1274ccbffe"
+checksum = "fcebe85c3cb0f83a7a89ae42691963416ab8500e82c941b68047ef5802170baf"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-cli"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,8 +11,9 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
-fbsim-core = "1.0.0-alpha.8"
+fbsim-core = "1.0.0-alpha.13"
 indicatif = "0.17.11"
 rand = "0.8.5"
 serde_json = "1.0.134"
+statrs = "0.18.0"
 tabwriter = "1.4.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ use fbsim_core::sim::BoxScoreSimulator;
 use fbsim_core::team::FootballTeam;
 use indicatif::ProgressBar;
 use serde_json;
+use statrs::statistics::Statistics;
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{Write, stdout};
 use std::str::FromStr;
@@ -74,6 +76,22 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
     let mut win_props = [[0.0_f64; 11]; 11];
     let mut tie_props = [[0.0_f64; 11]; 11];
 
+    // Instantiate zeroed BTreeMap to store the score frequencies
+    let mut score_freq: BTreeMap<i32, i32> = BTreeMap::new();
+    for i in 0..100 {
+        score_freq.insert(i as i32, 0_i32);
+    }
+
+    // Instantiate zeroed BTreeMaps to store the home and away scores
+    let mut home_scores: BTreeMap<i32, Vec<f64>> = BTreeMap::new();
+    let mut away_scores: BTreeMap<i32, Vec<f64>> = BTreeMap::new();
+    for i in 0..11 {
+        let off = ((10 - i) * 10) as i32;
+        let def = (i * 10) as i32;
+        home_scores.insert(off - def, Vec::new());
+        away_scores.insert(off - def, Vec::new());
+    }
+
     // Instantiate a progress bar for benchmark progress
     let progress_bar = ProgressBar::new(11 * 11 * 10000);
 
@@ -107,9 +125,23 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
                     &mut rng
                 ).unwrap();
 
+                // Track the observed final score in the score frequency map
+                let home_score = box_score.home_score();
+                let away_score = box_score.away_score();
+                let curr_home_score_count = score_freq.get(&home_score).unwrap();
+                score_freq.insert(home_score, curr_home_score_count + 1_i32);
+                let curr_away_score_count = score_freq.get(&away_score).unwrap();
+                score_freq.insert(away_score, curr_away_score_count + 1_i32);
+
+                // Track the observed home and away scores in the home/away score maps
+                let diff_home_scores: &mut Vec<f64> = home_scores.get_mut(&(home_off - away_def)).unwrap();
+                diff_home_scores.push(home_score as f64);
+                let diff_away_scores: &mut Vec<f64> = away_scores.get_mut(&(away_off - home_def)).unwrap();
+                diff_away_scores.push(away_score as f64);
+
                 // Decide whether this was a tie, or home win / away win
-                let was_tie = box_score.home_score() == box_score.away_score();
-                let home_win = box_score.home_score() > box_score.away_score();
+                let was_tie = home_score == away_score;
+                let home_win = home_score > away_score;
 
                 // Increment the tie proportions
                 tie_props[i][j] = if was_tie {
@@ -170,6 +202,47 @@ fn game_benchmark(_args: FbsimGameBenchmarkArgs) {
     write!(&mut tw, "{}", &tie_table_lines).unwrap();
     tw.flush().unwrap();
     println!("");
+
+    // Display the home mean and standard deviation score
+    let mut home_mean_std_lines = String::from("Skill Diff\tMean Score\tStd Score");
+    for (diff, scores) in home_scores.into_iter() {
+        let mean = scores.clone().mean();
+        let std = scores.clone().std_dev();
+        let home_mean_std_line = format!("{}\t{:.4}\t{:.4}", diff, mean, std);
+        home_mean_std_lines = home_mean_std_lines + "\n" + &home_mean_std_line;
+    }
+    println!("");
+    println!("Home score distribution:");
+    write!(&mut tw, "{}", &home_mean_std_lines).unwrap();
+    tw.flush().unwrap();
+    println!("");
+
+    // Display the away mean and standard deviation score
+    let mut away_mean_std_lines = String::from("Skill Diff\tMean Score\tStd Score");
+    for (diff, scores) in away_scores.into_iter() {
+        let mean = scores.clone().mean();
+        let std = scores.clone().std_dev();
+        let away_mean_std_line = format!("{}\t{:.4}\t{:.4}", diff, mean, std);
+        away_mean_std_lines = away_mean_std_lines + "\n" + &away_mean_std_line;
+    }
+    println!("");
+    println!("Away score distribution:");
+    write!(&mut tw, "{}", &away_mean_std_lines).unwrap();
+    tw.flush().unwrap();
+    println!("");
+
+    // Display the observed score frequency
+    let mut score_freq_table_lines = String::from("Score\tFrequency\tCount");
+    for (score, count) in score_freq.into_iter() {
+        let freq = count as f64 / (11_f64 * 11_f64 * 10000_f64);
+        let score_freq_table_line = format!("{}\t{:.4}%\t{}", score, freq * 100_f64, count);
+        score_freq_table_lines = score_freq_table_lines + "\n" + &score_freq_table_line;
+    }
+    println!("");
+    println!("Score frequency:");
+    write!(&mut tw, "{}", &score_freq_table_lines).unwrap();
+    tw.flush().unwrap();
+    println!("")
 }
 
 fn main() {


### PR DESCRIPTION
In this PR, I add new functionality in the `fbsim game benchmark` command to include the home & away mean & standard deviation score by skill differential, and the overall observed score frequency.

In the process, I also found that there was a bug in the core model - I had the coefficient and the intercept backwards - which led to worse teams performing better overall against better opponents.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/14