### PR TITLE
feat(permute): optionally shift and permute schedule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "fbsim-core"
 version = "1.0.0-alpha.15"
-source = "git+https://github.com/whatsacomputertho/fbsim-core.git?branch=main#dc2aacb400f5bd0bf05b052457ecd3fbdcf88fc3"
+source = "git+https://github.com/whatsacomputertho/fbsim-core.git?branch=main#db5628f611952842086f94b17a09cb938f1310fb"
 dependencies = [
  "chrono",
  "lazy_static",

--- a/src/cli/league/season/schedule.rs
+++ b/src/cli/league/season/schedule.rs
@@ -11,12 +11,21 @@ pub struct FbsimLeagueSeasonScheduleGenArgs {
     /// The number of weeks in the schedule
     #[arg(short='w')]
     #[arg(long="weeks")]
-    pub weeks: usize,
+    pub weeks: Option<usize>,
 
     /// The schedule seed
     #[arg(short='s')]
     #[arg(long="seed")]
     pub seed: Option<u64>,
+
+    /// How many places to shift the weeks of the schedule after generating it
+    #[arg(long="shift")]
+    pub shift: Option<usize>,
+
+    /// Whether to permute the schedule after generating it
+    #[arg(short='p')]
+    #[arg(long="permute")]
+    pub permute: Option<bool>,
 }
 
 /// Manage the schedule for the current season of a FootballSim league

--- a/src/league/season/schedule.rs
+++ b/src/league/season/schedule.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use fbsim_core::league::League;
+use fbsim_core::league::season::LeagueSeasonScheduleOptions;
 
 use crate::cli::league::season::schedule::FbsimLeagueSeasonScheduleGenArgs;
 
@@ -20,6 +21,13 @@ pub fn generate_schedule(args: FbsimLeagueSeasonScheduleGenArgs) -> Result<(), S
         Err(error) => return Err(format!("Error loading league from file: {}", error)),
     };
 
+    // Initialize schedule gen options
+    let options = LeagueSeasonScheduleOptions{
+        weeks: args.weeks,
+        shift: args.shift,
+        permute: args.permute,
+    };
+
     // Attempt to generate a schedule for the league
     let mut rng = match args.seed {
         Some(seed) => StdRng::seed_from_u64(seed),
@@ -28,7 +36,7 @@ pub fn generate_schedule(args: FbsimLeagueSeasonScheduleGenArgs) -> Result<(), S
             Err(error) => return Err(format!("Failed to instantiate rng: {}", error)),
         },
     };
-    let _schedule_gen = match league.generate_schedule(Some(args.weeks), &mut rng) {
+    let _schedule_gen = match league.generate_schedule(options, &mut rng) {
         Ok(()) => (),
         Err(error) => return Err(format!("Error generating league schedule: {}", error)),
     };


### PR DESCRIPTION
Adds the ability in the CLI to shift and permute the schedule after it is generated.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/25
- https://github.com/whatsacomputertho/fbsim-core/pull/31