### PR TITLE
feat(summaries): properly format and summarize get and list commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "fbsim-core"
 version = "1.0.0-alpha.15"
-source = "git+https://github.com/whatsacomputertho/fbsim-core.git?branch=main#db5628f611952842086f94b17a09cb938f1310fb"
+source = "git+https://github.com/whatsacomputertho/fbsim-core.git?branch=team-matchups-record#777cd0bf950767d9be3aa66be041f5c9829907bb"
 dependencies = [
  "chrono",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
-fbsim-core = { git = "https://github.com/whatsacomputertho/fbsim-core.git", branch = "main" }
+fbsim-core = { git = "https://github.com/whatsacomputertho/fbsim-core.git", branch = "team-matchups-record" }
 indicatif = "0.17.11"
 rand = "0.8.5"
 serde_json = "1.0.134"

--- a/src/cli/league/season.rs
+++ b/src/cli/league/season.rs
@@ -40,12 +40,22 @@ pub struct FbsimLeagueSeasonListArgs {
     pub league: String
 }
 
+/// Simulate the current season of the FootballSim league
+#[derive(Args, Clone)]
+pub struct FbsimLeagueSeasonSimArgs {
+    /// The input filepath for the league
+    #[arg(short='l')]
+    #[arg(long="league")]
+    pub league: String
+}
+
 /// Manage seasons for an existing FootballSim league
 #[derive(Subcommand, Clone)]
 pub enum FbsimLeagueSeasonSubcommand {
     Add(FbsimLeagueSeasonAddArgs),
     Get(FbsimLeagueSeasonGetArgs),
     List(FbsimLeagueSeasonListArgs),
+    Sim(FbsimLeagueSeasonSimArgs),
     Schedule {
         #[command(subcommand)]
         command: FbsimLeagueSeasonScheduleSubcommand

--- a/src/league/season.rs
+++ b/src/league/season.rs
@@ -2,5 +2,6 @@ pub mod add;
 pub mod get;
 pub mod list;
 pub mod schedule;
+pub mod sim;
 pub mod team;
 pub mod week;

--- a/src/league/season/get.rs
+++ b/src/league/season/get.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::{Write, stdout};
 
 use fbsim_core::league::League;
 use fbsim_core::league::season::LeagueSeason;
@@ -6,6 +7,7 @@ use fbsim_core::league::season::LeagueSeason;
 use crate::cli::league::season::FbsimLeagueSeasonGetArgs;
 
 use serde_json;
+use tabwriter::TabWriter;
 
 pub fn get_season(args: FbsimLeagueSeasonGetArgs) -> Result<(), String> {
     // Load the league from its file
@@ -20,23 +22,32 @@ pub fn get_season(args: FbsimLeagueSeasonGetArgs) -> Result<(), String> {
         Err(error) => return Err(format!("Error loading league from file: {}", error)),
     };
 
-    // TODO: Calculate a summary of the season
-    // TODO: Display the season summary in a nice looking way (not JSON)
-
     // Get a season from the league
     let season: &LeagueSeason = match league.season(args.year) {
         Some(season) => season,
         None => return Err(format!("No season found with year: {}", args.year)),
     };
 
-    // Serialize the season as JSON
-    let season_str_res = serde_json::to_string_pretty(&season);
-    let season_str = match season_str_res {
-        Ok(season_str) => season_str,
-        Err(error) => return Err(format!("Error serializing season: {}", error))
-    };
+    // Display the season teams in a table
+    let mut tw = TabWriter::new(stdout());
+    write!(&mut tw,"Team\tRecord\n").map_err(|e| e.to_string())?;
+    for (id, team) in season.teams().iter() {
+        let matchups = season.team_matchups(*id)?;
+        write!(
+            &mut tw, "{}\t{}\n",
+            team.name(), matchups.record()
+        ).map_err(|e| e.to_string())?;
+    }
 
-    // Print the season to the console
-    println!("{}", season_str);
+    // Display the season weeks in a table
+    write!(&mut tw,"\nWeek\tGames\tSimulated\n").map_err(|e| e.to_string())?;
+    for (i, week) in season.weeks().iter().enumerate() {
+        write!(
+            &mut tw, "{}\t{}\t{}\n", i,
+            week.matchups().len(),
+            week.matchups().iter().filter(|m| *m.complete()).collect::<Vec<_>>().len()
+        ).map_err(|e| e.to_string())?;
+    }
+    tw.flush().map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src/league/season/sim.rs
+++ b/src/league/season/sim.rs
@@ -1,0 +1,48 @@
+use std::fs;
+
+use fbsim_core::league::League;
+
+use crate::cli::league::season::FbsimLeagueSeasonSimArgs;
+
+use serde_json;
+
+pub fn sim_season(args: FbsimLeagueSeasonSimArgs) -> Result<(), String> {
+    // Load the league from its file as mutable
+    let file_res = &fs::read_to_string(&args.league);
+    let file = match file_res {
+        Ok(file) => file,
+        Err(error) => return Err(format!("Error loading league file: {}", error)),
+    };
+    let league_res = serde_json::from_str(file);
+    let mut league: League = match league_res {
+        Ok(league) => league,
+        Err(error) => return Err(format!("Error loading league from file: {}", error)),
+    };
+
+    // Simulate the current league season
+    let mut rng = rand::thread_rng();
+    match league.sim(&mut rng) {
+        Ok(()) => (),
+        Err(error) => return Err(
+            format!(
+                "Failed to simulate current season: {}",
+                error
+            )
+        ),
+    };
+
+    // Serialize the league as JSON
+    let league_res = serde_json::to_string_pretty(&league);
+    let league_str: String = match league_res {
+        Ok(league_str) => league_str,
+        Err(error) => return Err(format!("Error serializing league: {}", error)),
+    };
+
+    // Write the league back to its file
+    let write_res = fs::write(&args.league, league_str);
+    let _ = match write_res {
+        Ok(()) => (),
+        Err(error) => return Err(format!("Error writing league file: {}", error)),
+    };
+    Ok(())
+}

--- a/src/league/season/team/get.rs
+++ b/src/league/season/team/get.rs
@@ -1,10 +1,12 @@
 use std::fs;
+use std::io::{Write, stdout};
 
 use fbsim_core::league::League;
 
 use crate::cli::league::season::team::FbsimLeagueSeasonTeamGetArgs;
 
 use serde_json;
+use tabwriter::TabWriter;
 
 pub fn get_season_team(args: FbsimLeagueSeasonTeamGetArgs) -> Result<(), String> {
     // Load the league from its file
@@ -19,9 +21,6 @@ pub fn get_season_team(args: FbsimLeagueSeasonTeamGetArgs) -> Result<(), String>
         Err(error) => return Err(format!("Error loading league from file: {}", error)),
     };
 
-    // TODO: Calculate a summary of the team's performance over the season
-    // TODO: Display the summary in a nice looking way (not JSON)
-
     // Get the league season
     let season = match league.season(args.year) {
         Some(season) => season,
@@ -34,14 +33,35 @@ pub fn get_season_team(args: FbsimLeagueSeasonTeamGetArgs) -> Result<(), String>
         None => return Err(format!("No team found in season {} with id: {}", args.year, args.id)),
     };
 
-    // Serialize the season team as JSON
-    let team_res = serde_json::to_string_pretty(&team);
-    let team_str: String = match team_res {
-        Ok(team_str) => team_str,
-        Err(error) => return Err(format!("Error serializing season team: {}", error)),
-    };
+    // Get the league season team's matchups from the league season
+    let matchups = season.team_matchups(args.id)?;
 
-    // Print the team to stdout
-    println!("{}", team_str);
+    // Display the results in a table
+    let mut tw = TabWriter::new(stdout());
+    write!(&mut tw, "Team:\t{}\n", team.name()).map_err(|e| e.to_string())?;
+    write!(&mut tw, "Record:\t{}\n\n", matchups.record()).map_err(|e| e.to_string())?;
+
+    // Display each matchup
+    write!(
+        &mut tw,
+        "Week\tHome Team\tHome Score\tAway Team\tAway Score\n"
+    ).map_err(|e| e.to_string())?;
+    for (i, matchup) in matchups.matchups().iter().enumerate() {
+        match matchup {
+            Some(m) => {
+                write!(
+                    &mut tw, "{}\t{}\t{}\t{}\t{}\n", i,
+                    m.home_team(), m.home_score(),
+                    m.away_team(), m.away_score()
+                ).map_err(|e| e.to_string())?;
+            },
+            None => {
+                write!(
+                    &mut tw, "{}\t{}", i, "BYE"
+                ).map_err(|e| e.to_string())?;
+            },
+        }
+    }
+    tw.flush().map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use crate::league::team::list::list_teams;
 use crate::league::season::add::add_season;
 use crate::league::season::get::get_season;
 use crate::league::season::list::list_seasons;
+use crate::league::season::sim::sim_season;
 use crate::league::season::schedule::generate_schedule;
 use crate::league::season::team::add::add_season_team;
 use crate::league::season::team::get::get_season_team;
@@ -60,6 +61,7 @@ fn main() {
                 FbsimLeagueSeasonSubcommand::Add(args) => add_season(args.clone()),
                 FbsimLeagueSeasonSubcommand::Get(args) => get_season(args.clone()),
                 FbsimLeagueSeasonSubcommand::List(args) => list_seasons(args.clone()),
+                FbsimLeagueSeasonSubcommand::Sim(args) => sim_season(args.clone()),
                 FbsimLeagueSeasonSubcommand::Team{ command } => match command {
                     FbsimLeagueSeasonTeamSubcommand::Add(args) => add_season_team(args.clone()),
                     FbsimLeagueSeasonTeamSubcommand::Get(args) => get_season_team(args.clone()),


### PR DESCRIPTION
Adds tabwriter-based formatting to each `get` and `list` command by default.  For each command, a more proper summary is computed rather than just serializing the raw JSON.  Uses fbsim-core to summarize team performance over a season, or many seasons, depending on the command.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-cli/issues/9
- https://github.com/whatsacomputertho/fbsim-core/pull/32